### PR TITLE
Reset allowed tabs to disconnected tabs on disconnect

### DIFF
--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -153,8 +153,7 @@ $(document).ready(function () {
                     GUI.tab_switch_in_progress = false;
                     CONFIGURATOR.connectionValid = false;
                     GUI.connected_to = false;
-                    //GUI.allowedTabs = GUI.defaultAllowedTabsWhenDisconnected.slice();
-                    GUI.allowedTabs = GUI.defaultAllowedTabsWhenConnected.slice();
+                    GUI.allowedTabs = GUI.defaultAllowedTabsWhenDisconnected.slice();
 
                     /*
                      * Flush


### PR DESCRIPTION
Without this you can never flash firmware because the tool autoconnects at startup and then when you disconnect in order to flash firmware the list of allowed tabs is wrong.